### PR TITLE
Fix Qt crash at startup

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -603,7 +603,7 @@ void WalletView::replyFinished(QNetworkReply *reply)
         LogPrintf("Error connecting ticker\n");
     }
 
-    delete reply;
+    reply->deleteLater();
 }
 
 WalletModel* WalletView::getWalletModel(){


### PR DESCRIPTION
Fixes the crash at startup which outputs the stack trace like this:

```
#0  0x0000fffd568564e8 _ZNK15QNetworkRequest9attributeENS_9AttributeERK8QVariant (libQt5Network.so.5)
#1  0x0000fffd56840c14 _ZN28QNetworkAccessManagerPrivate16_q_replyFinishedEP13QNetworkReply (libQt5Network.so.5)
#2  0x0000fffd557fd140 _Z10doActivateILb0EEvP7QObjectiPPv (libQt5Core.so.5)
#3  0x0000fffd568b0954 _ZN28QNetworkReplyHttpImplPrivate8finishedEv (libQt5Network.so.5)
#4  0x0000fffd56955e84 _ZN21QNetworkReplyHttpImpl18qt_static_metacallEP7QObjectN11QMetaObject4CallEiPPv (libQt5Network.so.5)
#5  0x0000fffd557f6844 _ZN7QObject5eventEP6QEvent (libQt5Core.so.5)
#6  0x0000fffd562c065c _ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent (libQt5Widgets.so.5)
#7  0x0000fffd562c767c _ZN12QApplication6notifyEP7QObjectP6QEvent (libQt5Widgets.so.5)
#8  0x0000fffd557c7f54 _ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent (libQt5Core.so.5)
#9  0x0000fffd557caed8 _ZN23QCoreApplicationPrivate16sendPostedEventsEP7QObjectiP11QThreadData (libQt5Core.so.5)
#10 0x0000fffd55820360 _ZL23postEventSourceDispatchP8_GSourcePFiPvES1_ (libQt5Core.so.5)
#11 0x0000fffd5229deb4 g_main_context_dispatch (libglib-2.0.so.0)
#12 0x0000fffd5229e24c g_main_context_iterate.isra.21 (libglib-2.0.so.0)
#13 0x0000fffd5229e2e4 g_main_context_iteration (libglib-2.0.so.0)
#14 0x0000fffd55820004 _ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE (libQt5Core.so.5)
#15 0x0000fffd557c6924 _ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE (libQt5Core.so.5)
#16 0x0000fffd557cf450 _ZN16QCoreApplication4execEv (libQt5Core.so.5)
#17 0x0000aaae6137d44c n/a (***/noir-2.2.0.0/src/qt/noir-qt)
#18 0x0000aaae6137d44c n/a (***/noir-2.2.0.0/src/qt/noir-qt)
#19 0x0000fffd54900e64 __libc_start_main (libc.so.6)
```

by following the Qt document:
https://doc.qt.io/qt-5/qnetworkaccessmanager.html#finished
> Note: Do not delete the reply object in the slot connected to this signal. Use deleteLater().